### PR TITLE
fixed import paths and example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Linux networking in Golang
 
-**UPDATE: this package no longer uses original [libcontainer](https://github.com/docker/libcontainer) repo to source netlink package. It now uses [runc](https://github.com/opencontainers/runc) packages where the original libcontainer repo has been moved!!!**
-
 **tenus** is a [Golang](http://golang.org/) package which allows you to configure and manage Linux network devices programmatically. It communicates with Linux Kernel via [netlink](http://man7.org/linux/man-pages/man7/netlink.7.html) to facilitate creation and configuration of network devices on the Linux host. The package also allows for more advanced network setups with Linux containers including [Docker](https://github.com/dotcloud/docker/).
 
 **tenus** uses [runc](https://github.com/opencontainers/runc)'s implementation of **netlink** protocol. The package only works with newer Linux Kernels (3.10+) which are shipping reasonably new `netlink` protocol implementation, so **if you are running older kernel this package won't be of much use to you** I'm afraid. I have developed this package on Ubuntu [Trusty Tahr](http://releases.ubuntu.com/14.04/) which ships with 3.13+ and verified its functionality on [Precise Pangolin](http://releases.ubuntu.com/12.04/) with upgraded kernel to version 3.10. I could worked around the `netlink` issues by using `ioctl` syscalls, but I decided to prefer "pure netlink" implementation, so suck it old Kernels.

--- a/bridge_linux.go
+++ b/bridge_linux.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/opencontainers/runc/libcontainer/netlink"
+	"github.com/docker/libcontainer/netlink"
 )
 
 // Bridger embeds Linker interface and adds one extra function.

--- a/examples/tenus_vlanns_linux.go
+++ b/examples/tenus_vlanns_linux.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	// CREATE VLAN HOST INTERFACE
-	vlanDocker, err := tenus.NewVlanLinkWithOptions("eth1", tenus.VlanOptions{VlanDev: "vlanDckr", Id: 20})
+	vlanDocker, err := tenus.NewVlanLinkWithOptions("eth1", tenus.VlanOptions{Dev: "vlanDckr", Id: 20})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/tenuser_linux.go
+++ b/examples/tenuser_linux.go
@@ -85,7 +85,7 @@ func main() {
 	}
 
 	// CREATE MACVLAN INTERFACE AND BRING IT UP
-	macvlan, err := tenus.NewMacVlanLinkWithOptions("eth0", tenus.MacVlanOptions{Mode: "bridge", MacVlanDev: "macvlan01"})
+	macvlan, err := tenus.NewMacVlanLinkWithOptions("eth0", tenus.MacVlanOptions{Mode: "bridge", Dev: "macvlan01"})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -95,7 +95,7 @@ func main() {
 	}
 
 	// CREATE VLAN INTERFACE AND BRING IT UP
-	vlan, err := tenus.NewVlanLinkWithOptions("eth1", tenus.VlanOptions{Id: 10, VlanDev: "vlan01"})
+	vlan, err := tenus.NewVlanLinkWithOptions("eth1", tenus.VlanOptions{Id: 10, Dev: "vlan01"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/helpers_linux.go
+++ b/helpers_linux.go
@@ -16,8 +16,8 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/opencontainers/runc/libcontainer/netlink"
-	"github.com/opencontainers/runc/libcontainer/system"
+	"github.com/docker/libcontainer/netlink"
+	"github.com/docker/libcontainer/system"
 )
 
 // generates random string for makeNetInterfaceName()

--- a/link_linux.go
+++ b/link_linux.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/opencontainers/runc/libcontainer/netlink"
-	"github.com/opencontainers/runc/libcontainer/system"
+	"github.com/docker/libcontainer/netlink"
+	"github.com/docker/libcontainer/system"
 )
 
 // LinkOptions allows you to specify network link options.

--- a/macvlan_linux.go
+++ b/macvlan_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/opencontainers/runc/libcontainer/netlink"
+	"github.com/docker/libcontainer/netlink"
 )
 
 // Default MacVlan mode

--- a/macvtap_linux.go
+++ b/macvtap_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/opencontainers/runc/libcontainer/netlink"
+	"github.com/docker/libcontainer/netlink"
 )
 
 // MacVtaper embeds MacVlaner interface

--- a/network.go
+++ b/network.go
@@ -1,7 +1,7 @@
 package tenus
 
 import (
-	"github.com/opencontainers/runc/libcontainer/netlink"
+	"github.com/docker/libcontainer/netlink"
 )
 
 type NetworkOptions struct {

--- a/veth_linux.go
+++ b/veth_linux.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/opencontainers/runc/libcontainer/netlink"
-	"github.com/opencontainers/runc/libcontainer/system"
+	"github.com/docker/libcontainer/netlink"
+	"github.com/docker/libcontainer/system"
 )
 
 // VethOptions allows you to specify options for veth link.

--- a/vlan_linux.go
+++ b/vlan_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/opencontainers/runc/libcontainer/netlink"
+	"github.com/docker/libcontainer/netlink"
 )
 
 // VlanOptions allows you to specify options for vlan link.


### PR DESCRIPTION
The opencontainer/runc/libcontainer/netlink path no longer exists, so I replaced with docker/libcontainer/{netlink,system} instead so code compiles.  Also fixed two example codes that used old option names.