### PR TITLE
Added some extra utilities for working with bridge and interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,51 @@ func main() {
 }
 ```
 
+### Working with existing bridges and interfaces
+
+The following examples show how to retrieve exisiting interfaces as a tenus link and bridge
+
+```
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/milosgajdos83/tenus"
+)
+
+func main() {
+	// RETRIEVE EXISTING BRIDGE
+	br, err := tenus.BridgeFromName("bridge0")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// REMOVING AN IP FROM A BRIDGE INTERFACE (BEFORE RECONFIGURATION)
+	brIp, brIpNet, err := net.ParseCIDR("10.0.41.1/16")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := br.UnsetLinkIp(brIp, brIpNet); err != nil {
+		log.Fatal(err)
+	}
+
+	// RETRIEVE EXISTING INTERFACE
+	dl, err := tenus.NewLinkFrom("eth0")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// RENAMING AN INTERFACE BY NAME
+	if err := tenus.RenameInterfaceByName("vethPSQSEl", "vethNEWNAME"); err != nil {
+		log.Fatal(err)
+	}
+
+}
+```
+
 ### VLAN and MAC VLAN interfaces
 
 You can check out [VLAN](https://gist.github.com/milosgajdos83/9f68b1818dca886e9ae8) and [Mac VLAN](https://gist.github.com/milosgajdos83/296fb90d076f259a5b0a) examples, too.

--- a/bridge_linux.go
+++ b/bridge_linux.go
@@ -85,9 +85,8 @@ func NewBridgeWithName(ifcName string) (Bridger, error) {
 	}, nil
 }
 
-// NewBridgeFrom returns a network bridge on Linux host from the name passed as a parameter.
-// It is equivalent of running: ip link add name ${ifcName} type bridge
-// It returns error if the bridge can not be created.
+// BridgeFromName returns a tenus network bridge from an existing bridge of given name on the Linux host.
+// It returns error if the bridge of the given name cannot be found.
 func BridgeFromName(ifcName string) (Bridger, error) {
 	if ok, err := NetInterfaceNameValid(ifcName); !ok {
 		return nil, err

--- a/bridge_linux.go
+++ b/bridge_linux.go
@@ -85,6 +85,26 @@ func NewBridgeWithName(ifcName string) (Bridger, error) {
 	}, nil
 }
 
+// NewBridgeFrom returns a network bridge on Linux host from the name passed as a parameter.
+// It is equivalent of running: ip link add name ${ifcName} type bridge
+// It returns error if the bridge can not be created.
+func BridgeFromName(ifcName string) (Bridger, error) {
+	if ok, err := NetInterfaceNameValid(ifcName); !ok {
+		return nil, err
+	}
+
+	newIfc, err := net.InterfaceByName(ifcName)
+	if err != nil {
+		return nil, fmt.Errorf("Could not find the new interface: %s", err)
+	}
+
+	return &Bridge{
+		Link: Link{
+			ifc: newIfc,
+		},
+	}, nil
+}
+
 // AddToBridge adds network interfaces to network bridge.
 // It is equivalent of running: ip link set ${netIfc name} master ${netBridge name}
 // It returns error when it fails to add the network interface to bridge.

--- a/helpers_linux.go
+++ b/helpers_linux.go
@@ -33,6 +33,10 @@ func randomString(size int) string {
 	return string(bytes)
 }
 
+func MakeNetInterfaceName(base string) string {
+	return makeNetInterfaceName(base)
+}
+
 // generates new unused network interfaces name with given prefix
 func makeNetInterfaceName(base string) string {
 	for {

--- a/link_linux.go
+++ b/link_linux.go
@@ -82,7 +82,7 @@ func NewLink(ifcName string) (Linker, error) {
 	}, nil
 }
 
-// NewLinkFromName creates new tenus link on Linux host from an existing interface
+// NewLinkFrom creates new tenus link on Linux host from an existing interface of given name
 func NewLinkFrom(ifcName string) (Linker, error) {
 	if ok, err := NetInterfaceNameValid(ifcName); !ok {
 		return nil, err
@@ -97,7 +97,6 @@ func NewLinkFrom(ifcName string) (Linker, error) {
 		ifc: newIfc,
 	}, nil
 }
-
 
 // NewLinkWithOptions creates new network link on Linux host and sets some of its network
 // parameters passed in as LinkOptions
@@ -193,8 +192,8 @@ func (l *Link) SetLinkIp(ip net.IP, network *net.IPNet) error {
 	return netlink.NetworkLinkAddIp(l.NetInterface(), ip, network)
 }
 
-// SetLinkIp configures the link's IP address.
-// It is equivalent of running: ip address add ${address}/${mask} dev ${interface name}
+// UnsetLinkIp configures the link's IP address.
+// It is equivalent of running: ip address del ${address}/${mask} dev ${interface name}
 func (l *Link) UnsetLinkIp(ip net.IP, network *net.IPNet) error {
 	return netlink.NetworkLinkDelIp(l.NetInterface(), ip, network)
 }
@@ -257,6 +256,7 @@ func (l *Link) SetLinkNsToDocker(name string, dockerHost string) error {
 	return l.SetLinkNetNsPid(pid)
 }
 
+// RenameInterfaceByName renames an interface of given name.
 func RenameInterfaceByName(old string, newName string) error {
 	iface, err := net.InterfaceByName(old)
 	if err != nil {


### PR DESCRIPTION
Added BridgeFromName, MakeNetInterfaceName, NewLinkFrom, UnsetLinkIp, and RenameInterfaceByName

They should be pretty self explanatory. BridgeFromName and NewLinkFrom allow creating a tenus bridge/link from existing interfaces, RenameInterfaceByName allows renaming by name, MakeNetInterfaceName exposed makeNetInterfaceName publicly, UnsetLinkIp allows removal of an address from a tenus link.

Let me know if anything requires further explanations.