### PR TITLE
add RemoveSlaveIfc to Bridger Interfacer

### DIFF
--- a/bridge_linux.go
+++ b/bridge_linux.go
@@ -14,6 +14,8 @@ type Bridger interface {
 	Linker
 	// AddSlaveIfc adds network interface to the network bridge
 	AddSlaveIfc(*net.Interface) error
+	//RemoveSlaveIfc removes network interface from the network bridge
+	RemoveSlaveIfc(*net.Interface) error
 }
 
 // Bridge is Link which has zero or more slave network interfaces.


### PR DESCRIPTION
without RemoveSlaveIfc in Bridger,we can not use the RemoveSlaveIfc function
